### PR TITLE
Change sort order of episodes (Issue1)

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -11,7 +11,7 @@ $res = $client->request('GET', 'http://3ev.org/dev-test-api/');
 $data = json_decode($res->getBody(), true);
 
 //Sort the episodes
-array_multisort(array_keys($data), SORT_ASC, SORT_STRING, $data);
+array_multisort(array_keys($data), SORT_ASC, SORT_NATURAL, $data);
 
 //Render the template
 echo $twig->render('page.html', ["episodes" => $data]);


### PR DESCRIPTION
This pull request changes the sort order of the episodes so that they are now in the correct order for each season and episode within that season. Also altered the file paths for the pages css and js files so that they are correctly loaded in.

---

**Testing**

In a browser navigate to the home page of the site and the episodes should now be displayed correctly in the right order.

---

**Deployment steps**

Tell us what we would need to do to get your changes into production. (We are aware that in this test, this is mostly a case of merging your branch). e.g.

Merge branch `Issue1` into `master`

Compile assets: `./node_modules/.bin/gulp`

