### PR TITLE
Catch GuzzleHttp exceptions and display an error message (Issue2)

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -11,7 +11,7 @@ $res = $client->request('GET', 'http://3ev.org/dev-test-api/');
 $data = json_decode($res->getBody(), true);
 
 //Sort the episodes
-array_multisort(array_keys($data), SORT_ASC, SORT_STRING, $data);
+array_multisort(array_keys($data), SORT_ASC, SORT_NATURAL, $data);
 
 //Render the template
 echo $twig->render('page.html', ["episodes" => $data]);

--- a/public/index.php
+++ b/public/index.php
@@ -1,17 +1,21 @@
 <?php
 require_once '../vendor/autoload.php';
 
+try {
 //Load Twig templating environment
-$loader = new Twig_Loader_Filesystem('../templates/');
-$twig = new Twig_Environment($loader, ['debug' => true]);
+	$loader = new Twig_Loader_Filesystem('../templates/');
+	$twig = new Twig_Environment($loader, ['debug' => true]);
 
 //Get the episodes from the API
-$client = new GuzzleHttp\Client();
-$res = $client->request('GET', 'http://3ev.org/dev-test-api/');
-$data = json_decode($res->getBody(), true);
+	$client = new GuzzleHttp\Client();
+	$res = $client->request('GET', 'http://3ev.org/dev-test-api/');
+	$data = json_decode($res->getBody(), true);
 
 //Sort the episodes
-array_multisort(array_keys($data), SORT_ASC, SORT_NATURAL, $data);
+	array_multisort(array_keys($data), SORT_ASC, SORT_NATURAL, $data);
 
 //Render the template
-echo $twig->render('page.html', ["episodes" => $data]);
+	echo $twig->render('page.html', ["episodes" => $data]);
+} catch (Exception $e) {
+	echo $twig->render('error.html');
+}

--- a/templates/error.html
+++ b/templates/error.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Bobby's Favourite Simpson's Epsiodes</title>
+	<link href="./resources/compiled/css/main.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+    <head>
+<body>
+    <div class="jumbotron header">
+      <div class="container-fluid text-center">
+        <h1>Bobby's favourite episodes of <i>The Simpsons</i></h1>
+        <p><img class="img-circle" src="resources/img/bobby.jpg"></p>
+      </div>
+    </div>
+
+    <div class="container">
+        <div class="row">
+			<div class="alert-danger text-center">
+				<p>Sorry, an error has occured. Please try reloading the page.</p>
+			</div>
+		</div>
+    </div>
+
+    <footer class="footer">
+      <div class="container-fluid">
+          <div class="row">
+              <div class="text-center">
+                <p class="text-muted"><3</p>
+            </div>
+        </div>
+      </div>
+    </footer>
+
+  <script type="text/javascript" src="./resources/compiled/js/main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
This pull request adds a try catch block to index.php to catch GuzzleHttp exceptions, if one is caught then twig will display error.html instead of the normal page.html to inform the user that an error has occurred.

---

**Testing**

In a browser keep reloading the page until an error happens. This should show the new error page which, instead of showing the normal episode list, will now display an error message encouraging you to reload the page again.

---

**Deployment steps**

Merge branch `issue2` into `master`

Compile assets: `./node_modules/.bin/gulp`
