### PR TITLE
Fix CSS to match the design image (Issue3)

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -11,7 +11,7 @@ $res = $client->request('GET', 'http://3ev.org/dev-test-api/');
 $data = json_decode($res->getBody(), true);
 
 //Sort the episodes
-array_multisort(array_keys($data), SORT_ASC, SORT_STRING, $data);
+array_multisort(array_keys($data), SORT_ASC, SORT_NATURAL, $data);
 
 //Render the template
 echo $twig->render('page.html', ["episodes" => $data]);

--- a/public/index.php
+++ b/public/index.php
@@ -1,17 +1,21 @@
 <?php
 require_once '../vendor/autoload.php';
 
+try {
 //Load Twig templating environment
-$loader = new Twig_Loader_Filesystem('../templates/');
-$twig = new Twig_Environment($loader, ['debug' => true]);
+	$loader = new Twig_Loader_Filesystem('../templates/');
+	$twig = new Twig_Environment($loader, ['debug' => true]);
 
 //Get the episodes from the API
-$client = new GuzzleHttp\Client();
-$res = $client->request('GET', 'http://3ev.org/dev-test-api/');
-$data = json_decode($res->getBody(), true);
+	$client = new GuzzleHttp\Client();
+	$res = $client->request('GET', 'http://3ev.org/dev-test-api/');
+	$data = json_decode($res->getBody(), true);
 
 //Sort the episodes
-array_multisort(array_keys($data), SORT_ASC, SORT_NATURAL, $data);
+	array_multisort(array_keys($data), SORT_ASC, SORT_NATURAL, $data);
 
 //Render the template
-echo $twig->render('page.html', ["episodes" => $data]);
+	echo $twig->render('page.html', ["episodes" => $data]);
+} catch (Exception $e) {
+	echo $twig->render('error.html');
+}

--- a/public/resources/sass/base/_typography.scss
+++ b/public/resources/sass/base/_typography.scss
@@ -6,6 +6,6 @@ h4 {
     color: $gray-dark;
 
     small {
-        color: $gray-light;
+        color: $gray-base;
     }
 }

--- a/public/resources/sass/components/_episode.scss
+++ b/public/resources/sass/components/_episode.scss
@@ -1,7 +1,16 @@
 .episode {
     p {
         font-family: 'PT Serif', serif;
-        font-size: 15px;
-        line-height: 25px;            
+        font-size: $font-size-small;
+        line-height: 20px;
+		margin: 0px;
     }
+}
+
+.media {
+	margin-bottom: 25px;
+}
+
+.media-heading {
+	font-weight: bold;
 }

--- a/templates/error.html
+++ b/templates/error.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Bobby's Favourite Simpson's Epsiodes</title>
+	<link href="./resources/compiled/css/main.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+    <head>
+<body>
+    <div class="jumbotron header">
+      <div class="container-fluid text-center">
+        <h1>Bobby's favourite episodes of <i>The Simpsons</i></h1>
+        <p><img class="img-circle" src="resources/img/bobby.jpg"></p>
+      </div>
+    </div>
+
+    <div class="container">
+        <div class="row">
+			<div class="alert-danger text-center">
+				<p>Sorry, an error has occured. Please try reloading the page.</p>
+			</div>
+		</div>
+    </div>
+
+    <footer class="footer">
+      <div class="container-fluid">
+          <div class="row">
+              <div class="text-center">
+                <p class="text-muted"><3</p>
+            </div>
+        </div>
+      </div>
+    </footer>
+
+  <script type="text/javascript" src="./resources/compiled/js/main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
This pull request makes changes to the episode and typography partial Sass files so that the page matches the design.png. Specifically I changed colour of the season episode labels with the Sass variables already created, I also made the titles of the episodes to be bold. To get the synopsis text correct I altered the font size and line height. Then to make sure everything was spaced evenly like the design I added a margin to the synopsis text and to the bottom of bootstrap media class that houses the episodes.

---

**Testing**

In a browser verify that:
- episode titles are now bold
- season episode numbering text is now a darker shade of gray
- the synopsis text now has the right font size and line height
- the episode blocks are evenly spaced

---

**Deployment steps**

Merge branch `issue3` into `master`

Compile assets: `./node_modules/.bin/gulp`
